### PR TITLE
Simplify names board_* -> * (already in the class)

### DIFF
--- a/demo_pacman.py
+++ b/demo_pacman.py
@@ -9,15 +9,15 @@ game_speed = 0.00001
 game = Game(board, game_speed)
 
 # Create agents and add them to game
-pacman_init_node = board.board_nodes[(5, 5)]
+pacman_init_node = board.nodes[(5, 5)]
 pacman = PacMan(pacman_init_node)
 game.add_pacman(pacman)
 
-ghost1_init_node = board.board_nodes[(0, 0)]
+ghost1_init_node = board.nodes[(0, 0)]
 ghost1 = Ghost(ghost1_init_node)
 game.add_ghost(ghost1)
 
-ghost2_init_node = board.board_nodes[(0, 5)]
+ghost2_init_node = board.nodes[(0, 5)]
 ghost2 = Ghost(ghost2_init_node)
 game.add_ghost(ghost2)
 

--- a/pacman/board.py
+++ b/pacman/board.py
@@ -25,39 +25,39 @@ class Node:
 
 class Board:
     def __init__(self, board_path):
-        board_nodes, board_outline = self.build_board(board_path)
-        self.board_nodes = board_nodes
-        self.board_outline = board_outline
+        nodes, outline = self.build_board(board_path)
+        self.nodes = nodes
+        self.outline = outline
 
     def build_board(self, board_path):
-        board_outline = []
+        outline = []
         with open(board_path) as f:
             for line in f:
-                board_outline.append([int(char) for char in line.strip()])
-        board_outline = np.array(board_outline)
-        nb_board_row, nb_board_column = board_outline.shape
+                outline.append([int(char) for char in line.strip()])
+        outline = np.array(outline)
+        nb_row, nb_column = outline.shape
 
-        board_nodes = {}
+        nodes = {}
         # Create nodes
-        for row in range(nb_board_row):
-            for col in range(nb_board_column):
-                if(board_outline[row, col] == 1):
+        for row in range(nb_row):
+            for col in range(nb_column):
+                if(outline[row, col] == 1):
                     new_position = (row, col)
                     new_node = Node(new_position)
-                    board_nodes[new_position] = new_node
+                    nodes[new_position] = new_node
         # Link nodes to children
-        for position, current_node in board_nodes.items():
+        for position, current_node in nodes.items():
             children = []
             row = position[0]
             col = position[1]
-            if (row > 0 and (row - 1, col) in board_nodes.keys()):
-                children.append(board_nodes[(row - 1, col)])
-            if (row < nb_board_row and (row + 1, col) in board_nodes.keys()):
-                children.append(board_nodes[(row + 1, col)])
-            if (col > 0 and (row, col - 1) in board_nodes.keys()):
-                children.append(board_nodes[(row, col - 1)])
-            if (col < nb_board_column and
-                    (row, col + 1) in board_nodes.keys()):
-                children.append(board_nodes[(row, col + 1)])
+            if (row > 0 and (row - 1, col) in nodes.keys()):
+                children.append(nodes[(row - 1, col)])
+            if (row < nb_row and (row + 1, col) in nodes.keys()):
+                children.append(nodes[(row + 1, col)])
+            if (col > 0 and (row, col - 1) in nodes.keys()):
+                children.append(nodes[(row, col - 1)])
+            if (col < nb_column and
+                    (row, col + 1) in nodes.keys()):
+                children.append(nodes[(row, col + 1)])
             current_node.children_nodes = children
-        return board_nodes, board_outline
+        return nodes, outline

--- a/pacman/game.py
+++ b/pacman/game.py
@@ -22,7 +22,7 @@ class Game:
 
     def add_pacman(self, agent):
         target_position = agent.current_node.position
-        if (target_position in self.board.board_nodes):
+        if (target_position in self.board.nodes):
             self.pacman = agent
         else:
             raise InvalidPosition("Cannot add agent\
@@ -30,7 +30,7 @@ class Game:
 
     def add_ghost(self, agent):
         target_position = agent.current_node.position
-        if (target_position in self.board.board_nodes):
+        if (target_position in self.board.nodes):
             self.ghosts.append(agent)
         else:
             raise InvalidPosition("Cannot add agent\
@@ -99,8 +99,8 @@ class Game:
             self.draw_state(board_title)
 
     def compute_state(self):
-        current_board = self.board.board_outline.copy()
-        for position, node in self.board.board_nodes.items():
+        current_board = self.board.outline.copy()
+        for position, node in self.board.nodes.items():
             if (node.reward > 0):
                 current_board[node.position[0], node.position[1]] = 4
         for row, col in self.candies:


### PR DESCRIPTION
I thought that the prefix board_* for attributes of the class Board and local variables could be removed for readability.
What do you think ?